### PR TITLE
Add WEMOS D1 mini Lite board. 

### DIFF
--- a/boards/d1.json
+++ b/boards/d1.json
@@ -1,25 +1,25 @@
 {
   "build": {
-    "core": "esp8266", 
-    "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DESP8266_WEMOS_D1MINI", 
-    "f_cpu": "80000000L", 
-    "f_flash": "40000000L", 
-    "flash_mode": "dio", 
-    "ldscript": "esp8266.flash.4m1m.ld", 
-    "mcu": "esp8266", 
+    "core": "esp8266",
+    "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DESP8266_WEMOS_D1MINI",
+    "f_cpu": "80000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "dio",
+    "ldscript": "esp8266.flash.4m1m.ld",
+    "mcu": "esp8266",
     "variant": "d1"
-  }, 
+  },
   "frameworks": [
     "arduino"
-  ], 
-  "name": "WeMos D1(Retired)", 
+  ],
+  "name": "WEMOS D1 (Retired)",
   "upload": {
-    "maximum_ram_size": 81920, 
-    "maximum_size": 4194304, 
-    "require_upload_port": true, 
-    "resetmethod": "nodemcu", 
+    "maximum_ram_size": 81920,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "resetmethod": "nodemcu",
     "speed": 115200
-  }, 
-  "url": "http://www.wemos.cc/wiki/doku.php?id=en:d1", 
-  "vendor": "WeMos"
+  },
+  "url": "https://wiki.wemos.cc/products:d1:d1",
+  "vendor": "WEMOS"
 }

--- a/boards/d1_mini_lite.json
+++ b/boards/d1_mini_lite.json
@@ -1,25 +1,25 @@
 {
   "build": {
     "core": "esp8266",
-    "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DESP8266_WEMOS_D1MINI",
+    "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DESP8266_WEMOS_D1MINI -DESP8266_WEMOS_D1MINILITE",
     "f_cpu": "80000000L",
     "f_flash": "40000000L",
-    "flash_mode": "dio",
-    "ldscript": "esp8266.flash.4m1m.ld",
+    "flash_mode": "dout",
+    "ldscript": "esp8266.flash.1m64.ld",
     "mcu": "esp8266",
     "variant": "d1_mini"
   },
   "frameworks": [
     "arduino"
   ],
-  "name": "WEMOS D1 mini",
+  "name": "WEMOS D1 mini Lite",
   "upload": {
     "maximum_ram_size": 81920,
-    "maximum_size": 1044464,
+    "maximum_size": 958448,
     "require_upload_port": true,
     "resetmethod": "nodemcu",
     "speed": 115200
   },
-  "url": "https://wiki.wemos.cc/products:d1:d1_mini",
+  "url": "https://wiki.wemos.cc/products:d1:d1_mini_lite",
   "vendor": "WEMOS"
 }


### PR DESCRIPTION
Information directly from WEMOS repository that is linked by their official website.
https://github.com/wemos/Arduino_D1/blob/master/boards.txt

Two changes are the Flash SPI uses dout (double out only) instead of dio (double I/O), and the reduction to 1M flash.

Tested on D1 mini, D1 mini Lite, and D1 mini Pro.  All three work with the d1_mini_lite config.  As usual, only the mini and mini Pro work with the old d1_mini config.  Waiting to submit a dedicated Pro config until esptool and SDK properly supports 4MB+ flashing.