### PR TITLE
Add support for ESP8266 RTOS SDK framework

### DIFF
--- a/boards/d1.json
+++ b/boards/d1.json
@@ -10,7 +10,8 @@
     "variant": "d1"
   },
   "frameworks": [
-    "arduino"
+    "arduino",
+    "esp8266-rtos-sdk"
   ],
   "name": "WEMOS D1 (Retired)",
   "upload": {

--- a/boards/d1_mini.json
+++ b/boards/d1_mini.json
@@ -10,8 +10,9 @@
     "variant": "d1_mini"
   },
   "frameworks": [
-    "arduino"
-  ],
+    "arduino",
+    "esp8266-rtos-sdk"
+  ], 
   "name": "WEMOS D1 mini",
   "upload": {
     "maximum_ram_size": 81920,

--- a/boards/esp01.json
+++ b/boards/esp01.json
@@ -11,7 +11,8 @@
   }, 
   "frameworks": [
     "arduino", 
-    "simba"
+    "simba",
+    "esp8266-rtos-sdk"
   ], 
   "name": "Espressif Generic ESP8266 ESP-01 512k", 
   "upload": {

--- a/boards/esp01_1m.json
+++ b/boards/esp01_1m.json
@@ -11,7 +11,8 @@
   }, 
   "frameworks": [
     "arduino", 
-    "simba"
+    "simba",
+    "esp8266-rtos-sdk"
   ], 
   "name": "Espressif Generic ESP8266 ESP-01 1M", 
   "upload": {

--- a/boards/esp07.json
+++ b/boards/esp07.json
@@ -10,7 +10,8 @@
     "variant": "nodemcu"
   }, 
   "frameworks": [
-    "arduino"
+    "arduino",
+    "esp8266-rtos-sdk"
   ], 
   "name": "Espressif Generic ESP8266 ESP-07", 
   "upload": {

--- a/boards/esp12e.json
+++ b/boards/esp12e.json
@@ -11,7 +11,8 @@
   }, 
   "frameworks": [
     "arduino", 
-    "simba"
+    "simba",
+    "esp8266-rtos-sdk"
   ], 
   "name": "Espressif ESP8266 ESP-12E", 
   "upload": {

--- a/boards/esp210.json
+++ b/boards/esp210.json
@@ -10,7 +10,8 @@
     "variant": "generic"
   }, 
   "frameworks": [
-    "arduino"
+    "arduino",
+    "esp8266-rtos-sdk"
   ], 
   "name": "SweetPea ESP-210", 
   "upload": {

--- a/boards/esp8285.json
+++ b/boards/esp8285.json
@@ -10,7 +10,8 @@
     "variant": "generic"
   }, 
   "frameworks": [
-    "arduino"
+    "arduino",
+    "esp8266-rtos-sdk"
   ], 
   "name": "Generic ESP8285 Module", 
   "upload": {

--- a/boards/esp_wroom_02.json
+++ b/boards/esp_wroom_02.json
@@ -10,7 +10,9 @@
     "variant": "nodemcu"
   }, 
   "frameworks": [
-    "arduino"
+    "arduino",
+    "simba",
+    "esp8266-rtos-sdk"
   ], 
   "name": "ESP-WROOM-02", 
   "upload": {

--- a/boards/espduino.json
+++ b/boards/espduino.json
@@ -10,7 +10,8 @@
     "variant": "ESPDuino"
   }, 
   "frameworks": [
-    "arduino"
+    "arduino",
+    "esp8266-rtos-sdk"
   ], 
   "name": "ESPDuino (ESP-13 Module)", 
   "upload": {

--- a/boards/espectro.json
+++ b/boards/espectro.json
@@ -10,7 +10,8 @@
     "variant": "espectro"
   },
   "frameworks": [
-    "arduino"
+    "arduino",
+    "esp8266-rtos-sdk"
   ],
   "name": "ESPrectro Core",
   "upload": {

--- a/boards/espino.json
+++ b/boards/espino.json
@@ -10,7 +10,8 @@
     "variant": "espino"
   }, 
   "frameworks": [
-    "arduino"
+    "arduino",
+    "esp8266-rtos-sdk"
   ], 
   "name": "ESPino", 
   "upload": {

--- a/boards/espinotee.json
+++ b/boards/espinotee.json
@@ -10,7 +10,8 @@
     "variant": "espinotee"
   }, 
   "frameworks": [
-    "arduino"
+    "arduino",
+    "esp8266-rtos-sdk"
   ], 
   "name": "ThaiEasyElec ESPino", 
   "upload": {

--- a/boards/espresso_lite_v1.json
+++ b/boards/espresso_lite_v1.json
@@ -10,7 +10,8 @@
     "variant": "espresso_lite_v1"
   }, 
   "frameworks": [
-    "arduino"
+    "arduino",
+    "esp8266-rtos-sdk"
   ], 
   "name": "ESPresso Lite 1.0", 
   "upload": {

--- a/boards/espresso_lite_v2.json
+++ b/boards/espresso_lite_v2.json
@@ -10,7 +10,8 @@
     "variant": "espresso_lite_v2"
   }, 
   "frameworks": [
-    "arduino"
+    "arduino",
+    "esp8266-rtos-sdk"
   ], 
   "name": "ESPresso Lite 2.0", 
   "upload": {

--- a/boards/huzzah.json
+++ b/boards/huzzah.json
@@ -11,7 +11,8 @@
   }, 
   "frameworks": [
     "arduino", 
-    "simba"
+    "simba",
+    "esp8266-rtos-sdk"
   ], 
   "name": "Adafruit HUZZAH ESP8266", 
   "upload": {

--- a/boards/modwifi.json
+++ b/boards/modwifi.json
@@ -10,7 +10,8 @@
     "variant": "generic"
   }, 
   "frameworks": [
-    "arduino"
+    "arduino",
+    "esp8266-rtos-sdk"
   ], 
   "name": "Olimex MOD-WIFI-ESP8266(-DEV)", 
   "upload": {

--- a/boards/nodemcu.json
+++ b/boards/nodemcu.json
@@ -17,7 +17,8 @@
   }, 
   "frameworks": [
     "arduino", 
-    "simba"
+    "simba",
+    "esp8266-rtos-sdk"
   ], 
   "name": "NodeMCU 0.9 (ESP-12 Module)", 
   "upload": {

--- a/boards/nodemcuv2.json
+++ b/boards/nodemcuv2.json
@@ -17,7 +17,8 @@
   }, 
   "frameworks": [
     "arduino", 
-    "simba"
+    "simba",
+    "esp8266-rtos-sdk"
   ], 
   "name": "NodeMCU 1.0 (ESP-12E Module)", 
   "upload": {

--- a/boards/phoenix_v1.json
+++ b/boards/phoenix_v1.json
@@ -10,7 +10,8 @@
     "variant": "phoenix_v1"
   }, 
   "frameworks": [
-    "arduino"
+    "arduino",
+    "esp8266-rtos-sdk"
   ], 
   "name": "Phoenix 1.0", 
   "upload": {

--- a/boards/phoenix_v2.json
+++ b/boards/phoenix_v2.json
@@ -10,7 +10,8 @@
     "variant": "phoenix_v2"
   }, 
   "frameworks": [
-    "arduino"
+    "arduino",
+    "esp8266-rtos-sdk"
   ], 
   "name": "Phoenix 2.0", 
   "upload": {

--- a/boards/sparkfunBlynk.json
+++ b/boards/sparkfunBlynk.json
@@ -10,7 +10,8 @@
     "variant": "thing"
   },
   "frameworks": [
-    "arduino"
+    "arduino",
+    "esp8266-rtos-sdk"
   ],
   "name": "SparkFun Blynk Board",
   "upload": {

--- a/boards/thing.json
+++ b/boards/thing.json
@@ -10,7 +10,8 @@
     "variant": "thing"
   }, 
   "frameworks": [
-    "arduino"
+    "arduino",
+    "esp8266-rtos-sdk"
   ], 
   "name": "SparkFun ESP8266 Thing", 
   "upload": {

--- a/boards/thingdev.json
+++ b/boards/thingdev.json
@@ -10,7 +10,8 @@
     "variant": "thing"
   }, 
   "frameworks": [
-    "arduino"
+    "arduino",
+    "esp8266-rtos-sdk"
   ], 
   "name": "SparkFun ESP8266 Thing Dev", 
   "upload": {

--- a/boards/wifinfo.json
+++ b/boards/wifinfo.json
@@ -10,7 +10,8 @@
     "variant": "wifinfo"
   }, 
   "frameworks": [
-    "arduino"
+    "arduino",
+    "esp8266-rtos-sdk"
   ], 
   "name": "WifInfo", 
   "upload": {

--- a/builder/frameworks/esp8266-rtos-sdk.py
+++ b/builder/frameworks/esp8266-rtos-sdk.py
@@ -46,3 +46,18 @@ env.Prepend(
 env.Replace(
     LDSCRIPT_PATH=[join(FRAMEWORK_DIR, "ld", "eagle.app.v6.ld")],
 )
+
+#
+# Target: Build Driver Library
+#
+
+libs = []
+
+envsafe = env.Clone()
+
+libs.append(envsafe.BuildLibrary(
+    join(FRAMEWORK_DIR, "lib", "driver"),
+    join(FRAMEWORK_DIR, "driver_lib")
+))
+
+env.Prepend(LIBS=libs)

--- a/builder/frameworks/esp8266-rtos-sdk.py
+++ b/builder/frameworks/esp8266-rtos-sdk.py
@@ -1,0 +1,48 @@
+"""
+ESP8266 RTOS SDK
+
+Latest ESP8266 SDK based on FreeRTOS http://bbs.espressif.com
+
+http://github.com/espressif/ESP_8266_SDK
+"""
+
+from os.path import isdir, join
+
+from SCons.Script import DefaultEnvironment
+
+env = DefaultEnvironment()
+platform = env.PioPlatform()
+
+FRAMEWORK_DIR = platform.get_package_dir("framework-esp8266-rtos-sdk")
+assert isdir(FRAMEWORK_DIR)
+
+env.Prepend(
+    CPPPATH=[
+        join(FRAMEWORK_DIR, "include"),
+        join(FRAMEWORK_DIR, "extra_include"),
+        join(FRAMEWORK_DIR, "driver_lib", "include"),
+        join(FRAMEWORK_DIR, "include", "espressif"),
+        join(FRAMEWORK_DIR, "include", "lwip"),
+        join(FRAMEWORK_DIR, "include", "lwip", "ipv4"),
+        join(FRAMEWORK_DIR, "include", "lwip", "ipv6"),
+        join(FRAMEWORK_DIR, "include", "nopoll"),
+        join(FRAMEWORK_DIR, "include", "spiffs"),
+        join(FRAMEWORK_DIR, "include", "ssl"),
+        join(FRAMEWORK_DIR, "include", "json"),
+        join(FRAMEWORK_DIR, "include", "openssl"),
+    ],
+
+    LIBPATH=[
+        join(FRAMEWORK_DIR, "lib")
+    ],
+
+    LIBS=[
+        "cirom", "crypto", "driver", "espconn", "espnow", "freertos", "gcc",
+        "json", "hal", "lwip", "main", "mesh", "mirom", "net80211", "nopoll",
+        "phy", "pp", "pwm", "smartconfig", "spiffs", "ssl", "wpa", "wps"
+    ]
+)
+
+env.Replace(
+    LDSCRIPT_PATH=[join(FRAMEWORK_DIR, "ld", "eagle.app.v6.ld")],
+)

--- a/builder/main.py
+++ b/builder/main.py
@@ -214,7 +214,7 @@ if "uploadfs" in COMMAND_LINE_TARGETS:
 # Framework and SDK specific configuration
 #
 
-if "PIOFRAMEWORK" in env:
+if env.subst("$PIOFRAMEWORK") in ("arduino", "simba"):
     env.Append(
         LINKFLAGS=[
             "-Wl,-wrap,system_restart_local",
@@ -256,18 +256,34 @@ if "PIOFRAMEWORK" in env:
     if ota_port:
         env.Replace(UPLOADCMD="$UPLOADOTACMD")
 
-# Configure native SDK
 else:
+    upload_address = None
+    if env.subst("$PIOFRAMEWORK") == "esp8266-rtos-sdk":
+        env.Replace(
+            UPLOAD_ADDRESS="0x20000",
+        )
+    else: # Configure Native SDK
+        env.Append(
+            CPPPATH=[
+                join("$SDK_ESP8266_DIR", "include"), "$PROJECTSRC_DIR"
+            ],
+
+            LIBPATH=[
+                join("$SDK_ESP8266_DIR", "lib"),
+                join("$SDK_ESP8266_DIR", "ld")
+            ],
+        )
+        env.Replace(
+            LIBS=[
+                "c", "gcc", "phy", "pp", "net80211", "lwip", "wpa", "wpa2",
+                "main", "wps", "crypto", "json", "ssl", "pwm", "upgrade",
+                "smartconfig", "airkiss", "at"
+            ],
+            UPLOAD_ADDRESS = "0X40000"
+        )
+
+    # ESP8266 RTOS SDK and Native SDK common configuration
     env.Append(
-        CPPPATH=[
-            join("$SDK_ESP8266_DIR", "include"), "$PROJECTSRC_DIR"
-        ],
-
-        LIBPATH=[
-            join("$SDK_ESP8266_DIR", "lib"),
-            join("$SDK_ESP8266_DIR", "ld")
-        ],
-
         BUILDERS=dict(
             ElfToBin=Builder(
                 action=env.VerboseAction(" ".join([
@@ -289,13 +305,8 @@ else:
             )
         )
     )
-    env.Replace(
-        LIBS=[
-            "c", "gcc", "phy", "pp", "net80211", "lwip", "wpa", "wpa2",
-            "main", "wps", "crypto", "json", "ssl", "pwm", "upgrade",
-            "smartconfig", "airkiss", "at"
-        ],
 
+    env.Replace(
         UPLOADERFLAGS=[
             "-vv",
             "-cd", "$UPLOAD_RESETMETHOD",
@@ -303,10 +314,9 @@ else:
             "-cp", '"$UPLOAD_PORT"',
             "-ca", "0x00000",
             "-cf", "${SOURCES[0]}",
-            "-ca", "0x40000",
+            "-ca", "$UPLOAD_ADDRESS",
             "-cf", "${SOURCES[1]}"
         ],
-
         UPLOADCMD='$UPLOADER $UPLOADERFLAGS',
     )
 
@@ -329,13 +339,13 @@ if "nobuild" in COMMAND_LINE_TARGETS:
         __tmp_hook_before_pio_3_2()
         fetch_spiffs_size(env)
         target_firm = join("$BUILD_DIR", "spiffs.bin")
-    elif "PIOFRAMEWORK" not in env:
-        target_firm = [
-            join("$BUILD_DIR", "firmware_00000.bin"),
-            join("$BUILD_DIR", "firmware_40000.bin")
-        ]
-    else:
+    elif env.subst("$PIOFRAMEWORK") in ("arduino", "simba"):
         target_firm = join("$BUILD_DIR", "firmware.bin")
+    else:
+        target_firm = [
+            join("$BUILD_DIR", "eagle.flash.bin"),
+            join("$BUILD_DIR", "eagle.irom0text.bin")
+        ]
 else:
     if set(["buildfs", "uploadfs", "uploadfsota"]) & set(COMMAND_LINE_TARGETS):
         __tmp_hook_before_pio_3_2()
@@ -345,13 +355,13 @@ else:
         AlwaysBuild(env.Alias("buildfs", target_firm))
     else:
         target_elf = env.BuildProgram()
-        if "PIOFRAMEWORK" not in env:
-            target_firm = env.ElfToBin([join("$BUILD_DIR", "firmware_00000"),
-                                        join("$BUILD_DIR", "firmware_40000")],
-                                       target_elf)
-        else:
+        if env.subst("$PIOFRAMEWORK") in ("arduino", "simba"):
             target_firm = env.ElfToBin(
                 join("$BUILD_DIR", "firmware"), target_elf)
+        else:
+            target_firm = env.ElfToBin([join("$BUILD_DIR", "eagle.flash.bin"),
+                                        join("$BUILD_DIR", "eagle.irom0text.bin")],
+                                       target_elf)
 
 AlwaysBuild(env.Alias("nobuild", target_firm))
 target_buildprog = env.Alias("buildprog", target_firm, target_firm)

--- a/examples/esp8266-rtos-sdk-blink/.gitignore
+++ b/examples/esp8266-rtos-sdk-blink/.gitignore
@@ -1,0 +1,2 @@
+.pioenvs
+.piolibdeps

--- a/examples/esp8266-rtos-sdk-blink/lib/readme.txt
+++ b/examples/esp8266-rtos-sdk-blink/lib/readme.txt
@@ -1,0 +1,36 @@
+
+This directory is intended for the project specific (private) libraries.
+PlatformIO will compile them to static libraries and link to executable file.
+
+The source code of each library should be placed in separate directory, like
+"lib/private_lib/[here are source files]".
+
+For example, see how can be organized `Foo` and `Bar` libraries:
+
+|--lib
+|  |--Bar
+|  |  |--docs
+|  |  |--examples
+|  |  |--src
+|  |     |- Bar.c
+|  |     |- Bar.h
+|  |--Foo
+|  |  |- Foo.c
+|  |  |- Foo.h
+|  |- readme.txt --> THIS FILE
+|- platformio.ini
+|--src
+   |- main.c
+
+Then in `src/main.c` you should use:
+
+#include <Foo.h>
+#include <Bar.h>
+
+// rest H/C/CPP code
+
+PlatformIO will find your libraries automatically, configure preprocessor's
+include paths and build them.
+
+More information about PlatformIO Library Dependency Finder
+- http://docs.platformio.org/page/librarymanager/ldf.html

--- a/examples/esp8266-rtos-sdk-blink/platformio.ini
+++ b/examples/esp8266-rtos-sdk-blink/platformio.ini
@@ -1,0 +1,13 @@
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; http://docs.platformio.org/page/projectconf.html
+[env:esp_wroom_02]
+platform = espressif8266
+framework = esp8266-rtos-sdk
+board = esp_wroom_02

--- a/examples/esp8266-rtos-sdk-blink/src/main.c
+++ b/examples/esp8266-rtos-sdk-blink/src/main.c
@@ -1,0 +1,71 @@
+#include "esp_common.h"
+#include "freertos/task.h"
+#include "gpio.h"
+
+/******************************************************************************
+ * FunctionName : user_rf_cal_sector_set
+ * Description  : SDK just reversed 4 sectors, used for rf init data and paramters.
+ *                We add this function to force users to set rf cal sector, since
+ *                we don't know which sector is free in user's application.
+ *                sector map for last several sectors : ABCCC
+ *                A : rf cal
+ *                B : rf init data
+ *                C : sdk parameters
+ * Parameters   : none
+ * Returns      : rf cal sector
+*******************************************************************************/
+uint32 user_rf_cal_sector_set(void)
+{
+    flash_size_map size_map = system_get_flash_size_map();
+    uint32 rf_cal_sec = 0;
+    switch (size_map) {
+        case FLASH_SIZE_4M_MAP_256_256:
+            rf_cal_sec = 128 - 5;
+            break;
+
+        case FLASH_SIZE_8M_MAP_512_512:
+            rf_cal_sec = 256 - 5;
+            break;
+
+        case FLASH_SIZE_16M_MAP_512_512:
+        case FLASH_SIZE_16M_MAP_1024_1024:
+            rf_cal_sec = 512 - 5;
+            break;
+
+        case FLASH_SIZE_32M_MAP_512_512:
+        case FLASH_SIZE_32M_MAP_1024_1024:
+            rf_cal_sec = 1024 - 5;
+            break;
+
+        default:
+            rf_cal_sec = 0;
+            break;
+    }
+
+    return rf_cal_sec;
+}
+
+void task_blink(void* ignore)
+{
+    gpio16_output_conf();
+    while(true) {
+    	gpio16_output_set(0);
+        vTaskDelay(1000/portTICK_RATE_MS);
+    	gpio16_output_set(1);
+        vTaskDelay(1000/portTICK_RATE_MS);
+    }
+
+    vTaskDelete(NULL);
+}
+
+/******************************************************************************
+ * FunctionName : user_init
+ * Description  : entry of user application, init user function here
+ * Parameters   : none
+ * Returns      : none
+*******************************************************************************/
+void user_init(void)
+{
+    xTaskCreate(&task_blink, "startup", 2048, NULL, 1, NULL);
+}
+

--- a/platform.json
+++ b/platform.json
@@ -17,7 +17,8 @@
     "https://dl.bintray.com/platformio/dl-packages/manifest.json",
     "https://sourceforge.net/projects/platformio-storage/files/packages/manifest.json/download",
     "http://dl.platformio.org/packages/manifest.json",
-    "https://raw.githubusercontent.com/eerimoq/simba/master/make/platformio/manifest.json"
+    "https://raw.githubusercontent.com/eerimoq/simba/master/make/platformio/manifest.json",
+    "https://raw.githubusercontent.com/yanbe/framework-esp8266-rtos-sdk/master/manifest.json"
   ],
   "frameworks": {
     "arduino": {
@@ -27,6 +28,10 @@
     "simba": {
       "package": "framework-simba",
       "script": "builder/frameworks/simba.py"
+    },
+    "esp8266-rtos-sdk": {
+      "package": "framework-esp8266-rtos-sdk",
+      "script": "builder/frameworks/esp8266-rtos-sdk.py"
     }
   },
   "packages": {
@@ -38,6 +43,11 @@
       "type": "framework",
       "optional": true,
       "version": "~1.20300.1"
+    },
+    "framework-esp8266-rtos-sdk": {
+      "type": "framework",
+      "optional": true,
+      "version": ">=1.5.0-beta"
     },
     "framework-simba": {
       "type": "framework",


### PR DESCRIPTION
This pull request adds support for ESP8266 RTOS SDK as a PlatformIO framework.

ESP8266 RTOS SDK is a latest SDK for ESP8266 currently actively maintained by Espressif.
https://github.com/espressif/ESP8266_RTOS_SDK

The builder/main.py is largely modified. So I confirmed both existing example codes (arduino, simba, native-sdk) as well as added one can build and uploaded with real MCUs ( ESP-WROOM-02 and WeMOS D1 ). So the code expected to be compatible with existing projects using platform-espressif8266.

Packaging and hosting framework-esp8266-rtos-sdk is done in following repository, to fix some packaging error of official ESP8266 RTOS SDK as well as maintain manifest.json and package.json. 
https://github.com/yanbe/framework-esp8266-rtos-sdk/blob/master/package.bat
https://github.com/yanbe/framework-esp8266-rtos-sdk