### PR TITLE
add DigiStump Oak board

### DIFF
--- a/boards/oak.json
+++ b/boards/oak.json
@@ -1,0 +1,28 @@
+{
+  "build": {
+    "core": "esp8266",
+    "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DESP8266_OAK",
+    "f_cpu": "80000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "dio",
+    "ldscript": "eagle.flash.4m1m.ld",
+    "mcu": "esp8266",
+    "variant": "oak"
+  },
+  "connectivity": [
+    "wifi"
+  ],
+  "frameworks": [
+    "arduino"
+  ],
+  "name": "DigiStump Oak",
+  "upload": {
+    "maximum_ram_size": 81920,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "resetmethod": "ck",
+    "speed": 115200
+  },
+  "url": "http://digistump.com/category/22",
+  "vendor": "DigiStump"
+}


### PR DESCRIPTION
here's another try at this.   they've more-or-less dropped Particle support, so now it's just a plain ol' ESP8266 board.

please let me know if I need to retarget this PR to a diff branch; that wasn't clear.