### PR TITLE
Locked esp8266/Arduino version to 2.4.0-rc2

### DIFF
--- a/platform.json
+++ b/platform.json
@@ -41,7 +41,7 @@
     "framework-arduinoespressif8266": {
       "type": "framework",
       "optional": true,
-      "version": "https://github.com/esp8266/Arduino.git"
+      "version": "https://github.com/esp8266/Arduino.git#2.4.0-rc2"
     },
     "framework-esp8266-rtos-sdk": {
       "type": "framework",


### PR DESCRIPTION
Please consider accepting this PR into a new branch `arduino-core-2.4.0-rc2` so that there is an "official" platformio platform that is locked to the 2.4.0-rc2 Arduino Core version.