### PR TITLE
Update main.py

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -91,7 +91,9 @@ env.Replace(
     CPPDEFINES=[
         ("F_CPU", "$BOARD_F_CPU"),
         "__ets__",
-        "ICACHE_FLASH"
+        "ICACHE_FLASH",
+        "__SCHAR_MAX__=0x7f",
+        "__SHRT_MAX__=0x7fff"
     ],
 
     LINKFLAGS=[


### PR DESCRIPTION
Workaround for `identifier "uint8_t" is undefined` and `identifier "uint16_t" is undefined` warning in VS Code with `intelliSenseEngine: Default`
See [PlatformIO VS Code Issue #56](https://github.com/platformio/platformio-vscode-ide/issues/56#issuecomment-349566948)