### PR TITLE
Branch for espota if port resolved

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -16,6 +16,7 @@
 
 import re
 from os.path import join
+import socket
 
 
 from SCons.Script import (ARGUMENTS, COMMAND_LINE_TARGETS, AlwaysBuild,
@@ -261,9 +262,10 @@ if env.subst("$PIOFRAMEWORK") in ("arduino", "simba"):
     # Handle uploading via OTA
     ota_port = None
     if env.get("UPLOAD_PORT"):
-        ota_port = re.match(
-            r"\"?((([0-9]{1,3}\.){3}[0-9]{1,3})|[^\\/]+\.[^\\/]+)\"?$",
-            env.get("UPLOAD_PORT"))
+        try:
+            ota_port = socket.gethostbyname(env.get("UPLOAD_PORT"))
+        except socket.error:
+            pass
     if ota_port:
         env.Replace(UPLOADCMD="$UPLOADOTACMD")
 

--- a/builder/main.py
+++ b/builder/main.py
@@ -15,8 +15,8 @@
 # pylint: disable=redefined-outer-name
 
 import re
-from os.path import join
 import socket
+from os.path import join
 
 
 from SCons.Script import (ARGUMENTS, COMMAND_LINE_TARGETS, AlwaysBuild,


### PR DESCRIPTION
ESP_0CE07E is perfectly valid host name in intranet but when uploading it is treated as serial port.
Proposed is to try explicitly network-resolve provided port.
If this is not welcome, I believe it's easier and more robust to compose regexp for known serial ports, or use serial port list fetched from system (`util.get_serial_ports()`?)