### PR TITLE
Change default serial upload speed to 460k

### DIFF
--- a/boards/d1.json
+++ b/boards/d1.json
@@ -23,7 +23,7 @@
     "maximum_size": 4194304,
     "require_upload_port": true,
     "resetmethod": "nodemcu",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "https://wiki.wemos.cc/products:d1:d1",
   "vendor": "WEMOS"

--- a/boards/d1_mini.json
+++ b/boards/d1_mini.json
@@ -23,7 +23,7 @@
     "maximum_size": 4194304,
     "require_upload_port": true,
     "resetmethod": "nodemcu",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "https://wiki.wemos.cc/products:d1:d1_mini",
   "vendor": "WEMOS"

--- a/boards/d1_mini_lite.json
+++ b/boards/d1_mini_lite.json
@@ -21,7 +21,7 @@
     "maximum_size": 1048576,
     "require_upload_port": true,
     "resetmethod": "nodemcu",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "https://wiki.wemos.cc/products:d1:d1_mini_lite",
   "vendor": "WEMOS"

--- a/boards/d1_mini_pro.json
+++ b/boards/d1_mini_pro.json
@@ -23,7 +23,7 @@
     "maximum_size": 16777216,
     "require_upload_port": true,
     "resetmethod": "nodemcu",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "https://wiki.wemos.cc/products:d1:d1_mini",
   "vendor": "WEMOS"

--- a/boards/esp01.json
+++ b/boards/esp01.json
@@ -24,7 +24,7 @@
     "maximum_size": 524288,
     "require_upload_port": true,
     "resetmethod": "ck",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "http://www.esp8266.com/wiki/doku.php?id=esp8266-module-family",
   "vendor": "Espressif"

--- a/boards/esp01_1m.json
+++ b/boards/esp01_1m.json
@@ -23,7 +23,7 @@
     "maximum_size": 1048576,
     "require_upload_port": true,
     "resetmethod": "ck",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "http://www.esp8266.com/wiki/doku.php?id=esp8266-module-family",
   "vendor": "Espressif"

--- a/boards/esp07.json
+++ b/boards/esp07.json
@@ -23,7 +23,7 @@
     "maximum_size": 4194304,
     "require_upload_port": true,
     "resetmethod": "nodemcu",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "http://www.esp8266.com/wiki/doku.php?id=esp8266-module-family#esp-07",
   "vendor": "Espressif"

--- a/boards/esp12e.json
+++ b/boards/esp12e.json
@@ -24,7 +24,7 @@
     "maximum_size": 4194304,
     "require_upload_port": true,
     "resetmethod": "nodemcu",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "http://www.esp8266.com/wiki/doku.php?id=esp8266-module-family",
   "vendor": "Espressif"

--- a/boards/esp210.json
+++ b/boards/esp210.json
@@ -23,7 +23,7 @@
     "maximum_size": 4194304,
     "require_upload_port": true,
     "resetmethod": "ck",
-    "speed": 57600
+    "speed": 460800
   },
   "url": "http://wiki.sweetpeas.se/index.php?title=ESP-210",
   "vendor": "SweetPea"

--- a/boards/esp8285.json
+++ b/boards/esp8285.json
@@ -23,7 +23,7 @@
     "maximum_size": 1048576,
     "require_upload_port": true,
     "resetmethod": "ck",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "http://www.esp8266.com/wiki/doku.php?id=esp8266-module-family",
   "vendor": "Espressif"

--- a/boards/esp_wroom_02.json
+++ b/boards/esp_wroom_02.json
@@ -24,7 +24,7 @@
     "maximum_size": 2097152,
     "require_upload_port": true,
     "resetmethod": "nodemcu",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "http://www.esp8266.com/wiki/doku.php?id=esp8266-module-family",
   "vendor": "Espressif"

--- a/boards/espduino.json
+++ b/boards/espduino.json
@@ -23,7 +23,7 @@
     "maximum_size": 4194304,
     "require_upload_port": true,
     "resetmethod": "ck",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "https://www.tindie.com/products/doit/espduinowifi-uno-r3/",
   "vendor": "Doit"

--- a/boards/espectro.json
+++ b/boards/espectro.json
@@ -23,7 +23,7 @@
     "maximum_size": 4194304,
     "require_upload_port": true,
     "resetmethod": "nodemcu",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "https://shop.makestro.com/en/product/espectro-core/",
   "vendor": "DycodeX"

--- a/boards/espino.json
+++ b/boards/espino.json
@@ -23,7 +23,7 @@
     "maximum_size": 4194304,
     "require_upload_port": true,
     "resetmethod": "ck",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "http://www.espino.io",
   "vendor": "ESPino"

--- a/boards/espinotee.json
+++ b/boards/espinotee.json
@@ -23,7 +23,7 @@
     "maximum_size": 4194304,
     "require_upload_port": true,
     "resetmethod": "nodemcu",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "http://www.thaieasyelec.com/products/wireless-modules/wifi-modules/espino-wifi-development-board-detail.html",
   "vendor": "ThaiEasyElec"

--- a/boards/espresso_lite_v1.json
+++ b/boards/espresso_lite_v1.json
@@ -23,7 +23,7 @@
     "maximum_size": 4194304,
     "require_upload_port": true,
     "resetmethod": "nodemcu",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "http://www.espert.co",
   "vendor": "ESPert"

--- a/boards/espresso_lite_v2.json
+++ b/boards/espresso_lite_v2.json
@@ -23,7 +23,7 @@
     "maximum_size": 4194304,
     "require_upload_port": true,
     "resetmethod": "ck",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "http://www.espert.co",
   "vendor": "ESPert"

--- a/boards/gen4iod.json
+++ b/boards/gen4iod.json
@@ -23,7 +23,7 @@
     "maximum_size": 524288,
     "require_upload_port": true,
     "resetmethod": "ck",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "http://www.4dsystems.com.au/product/gen4_IoD/",
   "vendor": "4D Systems"

--- a/boards/heltec_wifi_kit_8.json
+++ b/boards/heltec_wifi_kit_8.json
@@ -23,7 +23,7 @@
     "maximum_size": 4194304,
     "require_upload_port": true,
     "resetmethod": "nodemcu",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "http://www.heltec.cn/project/wifi_kit_8/",
   "vendor": "Heltec"

--- a/boards/huzzah.json
+++ b/boards/huzzah.json
@@ -24,7 +24,7 @@
     "maximum_size": 4194304,
     "require_upload_port": true,
     "resetmethod": "nodemcu",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "https://www.adafruit.com/products/2471",
   "vendor": "Adafruit"

--- a/boards/inventone.json
+++ b/boards/inventone.json
@@ -24,7 +24,7 @@
     "maximum_size": 4194304,
     "require_upload_port": true,
     "resetmethod": "nodemcu",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "https://inventone.ng/",
   "vendor": "Invent One"

--- a/boards/modwifi.json
+++ b/boards/modwifi.json
@@ -23,7 +23,7 @@
     "maximum_size": 2097152,
     "require_upload_port": true,
     "resetmethod": "ck",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "https://www.olimex.com/Products/IoT/MOD-WIFI-ESP8266-DEV/open-source-hardware",
   "vendor": "Olimex"

--- a/boards/nodemcu.json
+++ b/boards/nodemcu.json
@@ -30,7 +30,7 @@
     "maximum_size": 4194304,
     "require_upload_port": true,
     "resetmethod": "nodemcu",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "http://www.nodemcu.com/",
   "vendor": "NodeMCU"

--- a/boards/nodemcuv2.json
+++ b/boards/nodemcuv2.json
@@ -30,7 +30,7 @@
     "maximum_size": 4194304,
     "require_upload_port": true,
     "resetmethod": "nodemcu",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "http://www.nodemcu.com/",
   "vendor": "NodeMCU"

--- a/boards/oak.json
+++ b/boards/oak.json
@@ -21,7 +21,7 @@
     "maximum_size": 4194304,
     "require_upload_port": true,
     "resetmethod": "ck",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "http://digistump.com/category/22",
   "vendor": "DigiStump"

--- a/boards/phoenix_v1.json
+++ b/boards/phoenix_v1.json
@@ -23,7 +23,7 @@
     "maximum_size": 4194304,
     "require_upload_port": true,
     "resetmethod": "nodemcu",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "http://www.esp8266.com/wiki/doku.php?id=esp8266-module-family",
   "vendor": "Espressif"

--- a/boards/phoenix_v2.json
+++ b/boards/phoenix_v2.json
@@ -23,7 +23,7 @@
     "maximum_size": 4194304,
     "require_upload_port": true,
     "resetmethod": "ck",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "http://www.esp8266.com/wiki/doku.php?id=esp8266-module-family",
   "vendor": "Espressif"

--- a/boards/sparkfunBlynk.json
+++ b/boards/sparkfunBlynk.json
@@ -23,7 +23,7 @@
     "maximum_size": 4194304,
     "require_upload_port": true,
     "resetmethod": "nodemcu",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "https://www.sparkfun.com/products/13794",
   "vendor": "SparkFun"

--- a/boards/thing.json
+++ b/boards/thing.json
@@ -23,7 +23,7 @@
     "maximum_size": 524288,
     "require_upload_port": true,
     "resetmethod": "ck",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "https://www.sparkfun.com/products/13231",
   "vendor": "SparkFun"

--- a/boards/thingdev.json
+++ b/boards/thingdev.json
@@ -23,7 +23,7 @@
     "maximum_size": 524288,
     "require_upload_port": true,
     "resetmethod": "nodemcu",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "https://www.sparkfun.com/products/13231",
   "vendor": "SparkFun"

--- a/boards/wifi_slot.json
+++ b/boards/wifi_slot.json
@@ -23,7 +23,7 @@
     "maximum_size": 4194304,
     "require_upload_port": true,
     "resetmethod": "nodemcu",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "http://wiki.amperka.ru/wifi-slot",
   "vendor": "Amperka"

--- a/boards/wifiduino.json
+++ b/boards/wifiduino.json
@@ -23,7 +23,7 @@
     "maximum_size": 4194304,
     "require_upload_port": true,
     "resetmethod": "nodemcu",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "https://www.facebook.com/WifiDuino/",
   "vendor": "WifiDuino"

--- a/boards/wifinfo.json
+++ b/boards/wifinfo.json
@@ -23,7 +23,7 @@
     "maximum_size": 1048576,
     "require_upload_port": true,
     "resetmethod": "nodemcu",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "http://www.esp8266.com/wiki/doku.php?id=esp8266-module-family",
   "vendor": "Espressif"

--- a/boards/wio_link.json
+++ b/boards/wio_link.json
@@ -23,7 +23,7 @@
     "maximum_size": 4194304,
     "require_upload_port": true,
     "resetmethod": "nodemcu",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "https://www.seeedstudio.com/Wio-Link-p-2604.html",
   "vendor": "SeeedStudio"

--- a/boards/wio_node.json
+++ b/boards/wio_node.json
@@ -23,7 +23,7 @@
     "maximum_size": 4194304,
     "require_upload_port": true,
     "resetmethod": "nodemcu",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "https://www.seeedstudio.com/Wio-Node-p-2637.html",
   "vendor": "SeeedStudio"

--- a/boards/xinabox_cw01.json
+++ b/boards/xinabox_cw01.json
@@ -23,7 +23,7 @@
     "maximum_size": 4194304,
     "require_upload_port": true,
     "resetmethod": "nodemcu",
-    "speed": 115200
+    "speed": 460800
   },
   "url": "https://xinabox.cc/products/cw01",
   "vendor": "XinaBox"


### PR DESCRIPTION
As of https://github.com/esp8266/Arduino/pull/5635 the
esp8266/Arduino core has defaulted to 460800 baud for
serial uploads and also silently limits the highest
supported upload rate of 921600 to 460800.

https://github.com/esp8266/Arduino/blob/77c4f5e5cfb2286d6862621bd78120f027d10a9f/tools/upload.py#L29

sed -i "s/\"speed\".*/\"speed\": 460800/g" *.json