### PR TITLE
Use https for dl.platformio.org

### DIFF
--- a/platform.json
+++ b/platform.json
@@ -15,7 +15,7 @@
   "version": "2.2.3",
   "packageRepositories": [
     "https://dl.bintray.com/platformio/dl-packages/manifest.json",
-    "http://dl.platformio.org/packages/manifest.json",
+    "https://dl.platformio.org/packages/manifest.json",
     "https://raw.githubusercontent.com/eerimoq/simba/master/make/platformio/manifest.json",
     "https://raw.githubusercontent.com/yanbe/framework-esp8266-rtos-sdk/master/manifest.json",
     "https://raw.githubusercontent.com/sanderv32/framework-esp8266-nonos-sdk/master/manifest.json"


### PR DESCRIPTION
Noticed the dl.platformio.org manifest was using http instead of https - but dl.platformio.org has a valid SSL certificate and is answering https requests correctly.

Since it's downloading binaries that are executed on the host machine, this is also good for security - in theory (I think, not tested) it should be possible to intercept the traffic and offer a new toolchain for example with malicious binaries.