### PR TITLE
Fix ESP-07 flash size

### DIFF
--- a/boards/esp07.json
+++ b/boards/esp07.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "arduino": {
-      "ldscript": "eagle.flash.1m64.ld"
+      "ldscript": "eagle.flash.1m256.ld"
     },
     "core": "esp8266",
     "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DARDUINO_ESP8266_ESP07",

--- a/boards/esp07.json
+++ b/boards/esp07.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "arduino": {
-      "ldscript": "eagle.flash.4m1m.ld"
+      "ldscript": "eagle.flash.1m64.ld"
     },
     "core": "esp8266",
     "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DARDUINO_ESP8266_ESP07",

--- a/boards/esp07.json
+++ b/boards/esp07.json
@@ -22,7 +22,7 @@
   "name": "Espressif Generic ESP8266 ESP-07",
   "upload": {
     "maximum_ram_size": 81920,
-    "maximum_size": 4194304,
+    "maximum_size": 1048576,
     "require_upload_port": true,
     "resetmethod": "nodemcu",
     "speed": 115200

--- a/boards/esp07.json
+++ b/boards/esp07.json
@@ -9,7 +9,7 @@
     "f_flash": "40000000L",
     "flash_mode": "qio",
     "mcu": "esp8266",
-    "variant": "nodemcu"
+    "variant": "generic"
   },
   "connectivity": [
     "wifi"
@@ -24,7 +24,7 @@
     "maximum_ram_size": 81920,
     "maximum_size": 1048576,
     "require_upload_port": true,
-    "resetmethod": "nodemcu",
+    "resetmethod": "ck",
     "speed": 115200
   },
   "url": "http://www.esp8266.com/wiki/doku.php?id=esp8266-module-family#esp-07",

--- a/boards/esp07.json
+++ b/boards/esp07.json
@@ -19,7 +19,7 @@
     "esp8266-rtos-sdk",
     "esp8266-nonos-sdk"
   ],
-  "name": "Espressif Generic ESP8266 ESP-07",
+  "name": "Espressif Generic ESP8266 ESP-07 1MB",
   "upload": {
     "maximum_ram_size": 81920,
     "maximum_size": 1048576,

--- a/boards/esp07s.json
+++ b/boards/esp07s.json
@@ -1,0 +1,32 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "eagle.flash.4m1m.ld"
+    },
+    "core": "esp8266",
+    "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DARDUINO_ESP8266_ESP07",
+    "f_cpu": "80000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "qio",
+    "mcu": "esp8266",
+    "variant": "nodemcu"
+  },
+  "connectivity": [
+    "wifi"
+  ],
+  "frameworks": [
+    "arduino",
+    "esp8266-rtos-sdk",
+    "esp8266-nonos-sdk"
+  ],
+  "name": "Espressif Generic ESP8266 ESP-07S",
+  "upload": {
+    "maximum_ram_size": 81920,
+    "maximum_size": 4194304,
+    "require_upload_port": true,
+    "resetmethod": "nodemcu",
+    "speed": 115200
+  },
+  "url": "http://www.esp8266.com/wiki/doku.php?id=esp8266-module-family#esp-07",
+  "vendor": "Espressif"
+}


### PR DESCRIPTION
Should fix #193. The ESP-07 has only 1MB of flash, it’s the ESP-07S which has 4MB.

I couldn't read the EEPROM because it was defined outside the flash.