### PR TITLE
Esp8266ExceptionDecoder: fix crash on empty line

### DIFF
--- a/monitor/filter_exception_decoder.py
+++ b/monitor/filter_exception_decoder.py
@@ -156,7 +156,7 @@ See https://docs.platformio.org/page/projectconf/build_configurations.html
                 self.buffer = ""
             last = idx + 1
 
-            if line[-1] == "\r":
+            if line and line[-1] == "\r":
                 line = line[:-1]
 
             extra = self.process_line(line)


### PR DESCRIPTION
Realized this too late, sorry.