### PR TITLE
Support for nonos-sdk 3.0.x and legacy OTA

### DIFF
--- a/builder/frameworks/esp8266-nonos-sdk.py
+++ b/builder/frameworks/esp8266-nonos-sdk.py
@@ -97,28 +97,7 @@ env.Append(
         "airkiss", "at", "c", "crypto", "driver", "espnow", "gcc", "json",
         "lwip", "main", "mbedtls", "net80211", "phy", "pp", "pwm",
         "smartconfig", "ssl", "upgrade", "wpa", "wpa2", "wps"
-    ],
-
-    BUILDERS=dict(
-        ElfToBin=Builder(
-            action=env.VerboseAction(" ".join([
-                '"%s"' % join(platform.get_package_dir("tool-esptool"), "esptool"),
-                "-eo", "$SOURCE",
-                "-bo", "${TARGET}",
-                "-bm", "$BOARD_FLASH_MODE",
-                "-bf", "${__get_board_f_flash(__env__)}",
-                "-bz", "${__get_flash_size(__env__)}",
-                "-bs", ".text",
-                "-bs", ".data",
-                "-bs", ".rodata",
-                "-bc", "-ec",
-                "-eo", "$SOURCE",
-                "-es", ".irom0.text", "${TARGET}.irom0text.bin",
-                "-ec", "-v"
-            ]), "Building $TARGET"),
-            suffix=".bin"
-        )
-    )
+    ]
 )
 
 

--- a/builder/frameworks/esp8266-nonos-sdk.py
+++ b/builder/frameworks/esp8266-nonos-sdk.py
@@ -121,10 +121,18 @@ env.Append(
     )
 )
 
+
+###################################################################################
+# common code between esp8266-nonos-sdk and esp8266-rtos-sdk for OTA support
+
+# choose LDSCRIPT_PATH based on OTA
 if not env.BoardConfig().get("build.ldscript", ""):
-    env.Replace(
+    if "ota" in BUILD_TARGETS:          # flash map size >= 5 only!!!
+        LDSCRIPT_PATH=join(FRAMEWORK_DIR, "ld", "eagle.app.v6.new.2048.ld")
+    else:
         LDSCRIPT_PATH=join(FRAMEWORK_DIR, "ld", "eagle.app.v6.ld")
-    )
+    env.Replace(LDSCRIPT_PATH=LDSCRIPT_PATH)
+
 
 # evaluate SPI_FLASH_SIZE_MAP flag for NONOS_SDK 3.x and set CCFLAG
 board_flash_size = int(env.BoardConfig().get("upload.maximum_size", 524288))
@@ -139,23 +147,79 @@ except:
 # for OTA, only size maps 5, 6, 8 and 9 are supported to avoid linking twice for user1 and user2
 
 env.Append(CCFLAGS=["-DSPI_FLASH_SIZE_MAP="+str(flash_size_map)])     # NONOS-SDK 3.x user_main.c need it
+env.Append(FLASH_SIZE_STR=flash_size_str)                             # required for custom uploader
 
-init_data_flash_address  = board_flash_size-0x4000     # 3fc000 for 4M board data_bin
 
+# create binaries list to upload
 
-esp_init_data_default_file = "esp_init_data_default_v08.bin"       # new in NONS 3.04
+if "ota" in BUILD_TARGETS:      # if OTA, flash user1 but generate user1 and user2
+    boot_bin  = join(FRAMEWORK_DIR, "bin", "boot_v1.7.bin")
+    user_bin  = join("$BUILD_DIR", "${PROGNAME}.bin.user1.bin")      # firmware.bin.user1.bin # user1.4096.new.6.bin
+    user_addr = 0x1000
+else:                           # non ota
+    boot_bin  = join("$BUILD_DIR", "${PROGNAME}.bin")                # firmware.bin # eagle.flash.bin
+    user_bin  = join("$BUILD_DIR", "${PROGNAME}.bin.irom0text.bin")  # firmware.bin.irom0text.bin # eagle.irom0text.bin
+    if (env['PIOFRAMEWORK'][0] == "esp8266-rtos-sdk"):
+        user_addr = 0x20000
+    else:
+        user_addr = 0x10000
+
+# check the init_data_default file to use
+esp_init_data_default_file = "esp_init_data_default_v08.bin"       # new in NONOS 3.04
 if not isfile(join(FRAMEWORK_DIR, "bin", esp_init_data_default_file)):
     esp_init_data_default_file = "esp_init_data_default.bin"
+    
+data_bin  = join(FRAMEWORK_DIR, "bin", esp_init_data_default_file)
+blank_bin = join(FRAMEWORK_DIR, "bin", "blank.bin")
+rf_cal_addr    = board_flash_size-0x5000     # 3fb000 for 4M board blank_bin
+phy_data_addr  = board_flash_size-0x4000     # 3fc000 for 4M board data_bin
+sys_param_addr = board_flash_size-0x2000     # 3fe000 for 4M board blank_bin
 
 env.Append(
     FLASH_EXTRA_IMAGES=[
-        ("0x10000", join("$BUILD_DIR", "${PROGNAME}.bin.irom0text.bin")),
-        (hex(init_data_flash_address),
-            join(FRAMEWORK_DIR, "bin", esp_init_data_default_file)),
-        (hex(init_data_flash_address + 0x2000),
-            join(FRAMEWORK_DIR, "bin", "blank.bin"))
+        (hex(0),              boot_bin),
+        (hex(user_addr),      user_bin),
+        (hex(phy_data_addr),  data_bin),
+        (hex(sys_param_addr), blank_bin),
+        (hex(rf_cal_addr),    blank_bin),
+        ("--flash_mode", "$BOARD_FLASH_MODE"),
+        ("--flash_freq", "$${__get_board_f_flash(__env__)}m"),
+        ("--flash_size", "$FLASH_SIZE_STR")     # required by NONOS 3.0.4
     ]
 )
+
+# register genbin.py BUILDER which allows to create OTA files 
+if "ota" in BUILD_TARGETS:      # if OTA, flash user1 but generate user1 and user2
+    env.Append(
+        BUILDERS=dict(
+            ElfToBin=Builder(
+                action=env.VerboseAction(" ".join([
+                    '"%s"' % env.subst("$PYTHONEXE"), join(platform.get_package_dir("tool-genbin"), "genbin.py"),
+                    "12",       # create firmware.bin.user1.bin and firmware.bin.user2.bin
+                    "$BOARD_FLASH_MODE", "${__get_board_f_flash(__env__)}m", "$FLASH_SIZE_STR",
+                    "$SOURCE", "${TARGET}.user1.bin", "${TARGET}.user2.bin"
+                           # could have used espressif naming: user1.4096.new.6.bin or user1.16384.new.9.bin
+                ]), "Building $TARGET"),
+                suffix=".bin"
+            )
+        )
+    )
+else:
+    env.Append(
+        BUILDERS=dict(
+            ElfToBin=Builder(
+                action=env.VerboseAction(" ".join([
+                    '"%s"' % env.subst("$PYTHONEXE"), join(platform.get_package_dir("tool-genbin"), "genbin.py"),
+                    "0",        # create firmware.bin and firmware.bin.irom0text.bin
+                    "$BOARD_FLASH_MODE", "${__get_board_f_flash(__env__)}m", "$FLASH_SIZE_STR",
+                    "$SOURCE", "${TARGET}", "${TARGET}.irom0text.bin"
+                ]), "Building $TARGET"),
+                suffix=".bin"
+            )
+        )
+    )
+
+###################################################################################
 
 
 #

--- a/builder/frameworks/esp8266-nonos-sdk.py
+++ b/builder/frameworks/esp8266-nonos-sdk.py
@@ -61,7 +61,8 @@ env.Append(
     CXXFLAGS=[
         "-fno-rtti",
         "-fno-exceptions",
-        "-std=c++11"
+        "-std=c++11",
+        "-Wno-literal-suffix"
     ],
 
     LINKFLAGS=[
@@ -83,16 +84,8 @@ env.Append(
 
     CPPPATH=[
         join(FRAMEWORK_DIR, "include"),
-        join(FRAMEWORK_DIR, "extra_include"),
         join(FRAMEWORK_DIR, "driver_lib", "include"),
-        join(FRAMEWORK_DIR, "include", "espressif"),
-        join(FRAMEWORK_DIR, "include", "lwip"),
-        join(FRAMEWORK_DIR, "include", "lwip", "ipv4"),
-        join(FRAMEWORK_DIR, "include", "lwip", "ipv6"),
-        join(FRAMEWORK_DIR, "include", "nopoll"),
-        join(FRAMEWORK_DIR, "include", "ssl"),
-        join(FRAMEWORK_DIR, "include", "json"),
-        join(FRAMEWORK_DIR, "include", "openssl")
+        join(FRAMEWORK_DIR, "third_party", "include")
     ],
 
     LIBPATH=[
@@ -102,7 +95,7 @@ env.Append(
 
     LIBS=[
         "airkiss", "at", "c", "crypto", "driver", "espnow", "gcc", "json",
-        "lwip", "main", "mbedtls", "mesh", "net80211", "phy", "pp", "pwm",
+        "lwip", "main", "mbedtls", "net80211", "phy", "pp", "pwm",
         "smartconfig", "ssl", "upgrade", "wpa", "wpa2", "wps"
     ],
 
@@ -164,9 +157,10 @@ env.Append(
 
 libs = []
 
-libs.append(env.BuildLibrary(
-    join(FRAMEWORK_DIR, "lib", "driver"),
-    join(FRAMEWORK_DIR, "driver_lib")
-))
+if False:
+    libs.append(env.BuildLibrary(
+        join(FRAMEWORK_DIR, "lib", "driver"),
+        join(FRAMEWORK_DIR, "driver_lib")
+    ))
 
 env.Prepend(LIBS=libs)

--- a/builder/frameworks/esp8266-rtos-sdk.py
+++ b/builder/frameworks/esp8266-rtos-sdk.py
@@ -106,28 +106,7 @@ env.Append(
         "cirom", "crypto", "driver", "espconn", "espnow", "freertos", "gcc",
         "json", "hal", "lwip", "main", "mbedtls", "mesh", "mirom", "net80211", "nopoll",
         "phy", "pp", "pwm", "smartconfig", "spiffs", "ssl", "wpa", "wps"
-    ],
-
-    BUILDERS=dict(
-        ElfToBin=Builder(
-            action=env.VerboseAction(" ".join([
-                '"%s"' % join(platform.get_package_dir("tool-esptool"), "esptool"),
-                "-eo", "$SOURCE",
-                "-bo", "${TARGET}",
-                "-bm", "$BOARD_FLASH_MODE",
-                "-bf", "${__get_board_f_flash(__env__)}",
-                "-bz", "${__get_flash_size(__env__)}",
-                "-bs", ".text",
-                "-bs", ".data",
-                "-bs", ".rodata",
-                "-bc", "-ec",
-                "-eo", "$SOURCE",
-                "-es", ".irom0.text", "${TARGET}.irom0text.bin",
-                "-ec", "-v"
-            ]), "Building $TARGET"),
-            suffix=".bin"
-        )
-    )
+    ]
 )
 
 

--- a/builder/frameworks/esp8266-rtos-sdk.py
+++ b/builder/frameworks/esp8266-rtos-sdk.py
@@ -61,7 +61,8 @@ env.Append(
     CXXFLAGS=[
         "-fno-rtti",
         "-fno-exceptions",
-        "-std=c++11"
+        "-std=c++11",
+        "-Wno-literal-suffix"
     ],
 
     LINKFLAGS=[
@@ -103,7 +104,7 @@ env.Append(
 
     LIBS=[
         "cirom", "crypto", "driver", "espconn", "espnow", "freertos", "gcc",
-        "json", "hal", "lwip", "main", "mesh", "mirom", "net80211", "nopoll",
+        "json", "hal", "lwip", "main", "mbedtls", "mesh", "mirom", "net80211", "nopoll",
         "phy", "pp", "pwm", "smartconfig", "spiffs", "ssl", "wpa", "wps"
     ],
 

--- a/builder/frameworks/esp8266-rtos-sdk.py
+++ b/builder/frameworks/esp8266-rtos-sdk.py
@@ -21,7 +21,7 @@ microcontrollers
 https://github.com/espressif/ESP8266_RTOS_SDK
 """
 
-from os.path import isdir, join
+from os.path import isdir, join, isfile
 
 from SCons.Script import Builder, DefaultEnvironment
 
@@ -130,35 +130,106 @@ env.Append(
     )
 )
 
-if not env.BoardConfig().get("build.ldscript", ""):
-    env.Replace(
-        LDSCRIPT_PATH=join(FRAMEWORK_DIR, "ld", "eagle.app.v6.ld"),
-    )
 
-# Extra flash images
-board_flash_size = int(env.BoardConfig().get("upload.maximum_size", 0))
-if board_flash_size > 8388608:
-    init_data_flash_address = 0xffc000  # for 16 MB
-elif board_flash_size > 4194304:
-    init_data_flash_address = 0x7fc000  # for 8 MB
-elif board_flash_size > 2097152:
-    init_data_flash_address = 0x3fc000  # for 4 MB
-elif board_flash_size > 1048576:
-    init_data_flash_address = 0x1fc000  # for 2 MB
-elif board_flash_size > 524288:
-    init_data_flash_address = 0xfc000  # for 1 MB
-else:
-    init_data_flash_address = 0x7c000  # for 512 kB
+###################################################################################
+# common code between esp8266-nonos-sdk and esp8266-rtos-sdk for OTA support
+
+# choose LDSCRIPT_PATH based on OTA
+if not env.BoardConfig().get("build.ldscript", ""):
+    if "ota" in BUILD_TARGETS:          # flash map size >= 5 only!!!
+        LDSCRIPT_PATH=join(FRAMEWORK_DIR, "ld", "eagle.app.v6.new.2048.ld")
+    else:
+        LDSCRIPT_PATH=join(FRAMEWORK_DIR, "ld", "eagle.app.v6.ld")
+    env.Replace(LDSCRIPT_PATH=LDSCRIPT_PATH)
+
+
+# evaluate SPI_FLASH_SIZE_MAP flag for NONOS_SDK 3.x and set CCFLAG
+board_flash_size = int(env.BoardConfig().get("upload.maximum_size", 524288))
+flash_size_maps = [0.5, 0.25, 1.0, 0.0, 0.0, 2.0, 4.0, 0.0, 8.0, 16.0]  # ignore maps 3 and 4.prefer 5 and 6
+flash_sizes_str = ['512KB','256KB','1MB','2MB','4MB','2MB-c1','4MB-c1','4MB-c2','8MB','16MB']
+try:
+    flash_size_map = flash_size_maps.index(board_flash_size/1048576)
+    flash_size_str = flash_sizes_str[flash_size_map]
+except:
+    flash_size_map = 6
+    flash_size_str = '4MB-c1'
+# for OTA, only size maps 5, 6, 8 and 9 are supported to avoid linking twice for user1 and user2
+
+env.Append(CCFLAGS=["-DSPI_FLASH_SIZE_MAP="+str(flash_size_map)])     # NONOS-SDK 3.x user_main.c need it
+env.Append(FLASH_SIZE_STR=flash_size_str)                             # required for custom uploader
+
+
+# create binaries list to upload
+
+if "ota" in BUILD_TARGETS:      # if OTA, flash user1 but generate user1 and user2
+    boot_bin  = join(FRAMEWORK_DIR, "bin", "boot_v1.7.bin")
+    user_bin  = join("$BUILD_DIR", "${PROGNAME}.bin.user1.bin")      # firmware.bin.user1.bin # user1.4096.new.6.bin
+    user_addr = 0x1000
+else:                           # non ota
+    boot_bin  = join("$BUILD_DIR", "${PROGNAME}.bin")                # firmware.bin # eagle.flash.bin
+    user_bin  = join("$BUILD_DIR", "${PROGNAME}.bin.irom0text.bin")  # firmware.bin.irom0text.bin # eagle.irom0text.bin
+    if (env['PIOFRAMEWORK'][0] == "esp8266-rtos-sdk"):
+        user_addr = 0x20000
+    else:
+        user_addr = 0x10000
+
+# check the init_data_default file to use
+esp_init_data_default_file = "esp_init_data_default_v08.bin"       # new in NONOS 3.04
+if not isfile(join(FRAMEWORK_DIR, "bin", esp_init_data_default_file)):
+    esp_init_data_default_file = "esp_init_data_default.bin"
+    
+data_bin  = join(FRAMEWORK_DIR, "bin", esp_init_data_default_file)
+blank_bin = join(FRAMEWORK_DIR, "bin", "blank.bin")
+rf_cal_addr    = board_flash_size-0x5000     # 3fb000 for 4M board blank_bin
+phy_data_addr  = board_flash_size-0x4000     # 3fc000 for 4M board data_bin
+sys_param_addr = board_flash_size-0x2000     # 3fe000 for 4M board blank_bin
 
 env.Append(
     FLASH_EXTRA_IMAGES=[
-        ("0x20000", join("$BUILD_DIR", "${PROGNAME}.bin.irom0text.bin")),
-        (hex(init_data_flash_address),
-            join(FRAMEWORK_DIR, "bin", "esp_init_data_default.bin")),
-        (hex(init_data_flash_address + 0x2000),
-            join(FRAMEWORK_DIR, "bin", "blank.bin"))
+        (hex(0),              boot_bin),
+        (hex(user_addr),      user_bin),
+        (hex(phy_data_addr),  data_bin),
+        (hex(sys_param_addr), blank_bin),
+        (hex(rf_cal_addr),    blank_bin),
+        ("--flash_mode", "$BOARD_FLASH_MODE"),
+        ("--flash_freq", "$${__get_board_f_flash(__env__)}m"),
+        ("--flash_size", "$FLASH_SIZE_STR")     # required by NONOS 3.0.4
     ]
 )
+
+# register genbin.py BUILDER which allows to create OTA files 
+if "ota" in BUILD_TARGETS:      # if OTA, flash user1 but generate user1 and user2
+    env.Append(
+        BUILDERS=dict(
+            ElfToBin=Builder(
+                action=env.VerboseAction(" ".join([
+                    '"%s"' % env.subst("$PYTHONEXE"), join(platform.get_package_dir("tool-genbin"), "genbin.py"),
+                    "12",       # create firmware.bin.user1.bin and firmware.bin.user2.bin
+                    "$BOARD_FLASH_MODE", "${__get_board_f_flash(__env__)}m", "$FLASH_SIZE_STR",
+                    "$SOURCE", "${TARGET}.user1.bin", "${TARGET}.user2.bin"
+                           # could have used espressif naming: user1.4096.new.6.bin or user1.16384.new.9.bin
+                ]), "Building $TARGET"),
+                suffix=".bin"
+            )
+        )
+    )
+else:
+    env.Append(
+        BUILDERS=dict(
+            ElfToBin=Builder(
+                action=env.VerboseAction(" ".join([
+                    '"%s"' % env.subst("$PYTHONEXE"), join(platform.get_package_dir("tool-genbin"), "genbin.py"),
+                    "0",        # create firmware.bin and firmware.bin.irom0text.bin
+                    "$BOARD_FLASH_MODE", "${__get_board_f_flash(__env__)}m", "$FLASH_SIZE_STR",
+                    "$SOURCE", "${TARGET}", "${TARGET}.irom0text.bin"
+                ]), "Building $TARGET"),
+                suffix=".bin"
+            )
+        )
+    )
+
+###################################################################################
+
 
 #
 # Target: Build Driver Library

--- a/builder/main.py
+++ b/builder/main.py
@@ -251,6 +251,7 @@ else:
 env.AddPlatformTarget("buildfs", target_firm, target_firm, "Build Filesystem Image")
 AlwaysBuild(env.Alias("nobuild", target_firm))
 target_buildprog = env.Alias("buildprog", target_firm, target_firm)
+env.AddPlatformTarget("ota", target_firm, target_firm, "Build Espressif OTA images")
 
 # update max upload size based on CSV file
 if env.get("PIOMAINPROG"):
@@ -325,6 +326,10 @@ elif upload_protocol == "esptool":
         UPLOADCMD='"$PYTHONEXE" "$UPLOADER" $UPLOADERFLAGS 0x0 $SOURCE'
     )
     for image in env.get("FLASH_EXTRA_IMAGES", []):
+        if image[0]=='0x0':        # a bootloader is furnished. clean the UPLOADCMD
+            env.Replace(
+                UPLOADCMD='"$PYTHONEXE" "$UPLOADER" $UPLOADERFLAGS'
+            )
         env.Append(UPLOADERFLAGS=[image[0], env.subst(image[1])])
 
     if "uploadfs" in COMMAND_LINE_TARGETS:

--- a/platform.json
+++ b/platform.json
@@ -63,6 +63,11 @@
       "owner": "platformio",
       "version": "~3.0.4"
     },
+    "tool-genbin": {
+      "type": "uploader",
+      "owner": "platformio",
+      "version": "~1.0.0"
+    },
     "tool-esptool": {
       "type": "uploader",
       "owner": "platformio",

--- a/platform.json
+++ b/platform.json
@@ -55,13 +55,13 @@
       "type": "framework",
       "optional": true,
       "owner": "platformio",
-      "version": ">=1.5.0-beta"
+      "version": "==1.5.0-beta.5"
     },
     "framework-esp8266-nonos-sdk": {
       "type": "framework",
       "optional": true,
       "owner": "platformio",
-      "version": ">=2.1.0"
+      "version": "~3.0.4"
     },
     "tool-esptool": {
       "type": "uploader",

--- a/platform.py
+++ b/platform.py
@@ -19,8 +19,6 @@ class Espressif8266Platform(PlatformBase):
 
     def configure_default_packages(self, variables, targets):
         framework = variables.get("pioframework", [])
-        if "arduino" not in framework:
-            self.packages['toolchain-xtensa']['version'] = "~1.40802.0"
         if "buildfs" in targets:
             self.packages['tool-mkspiffs']['optional'] = False
             self.packages['tool-mklittlefs']['optional'] = False


### PR DESCRIPTION
This PR implements support for the latest Espressif nonos-sdk (second commit) and support for legacy OTA usable with nonos-sdk and rtos-sdk (v1.5) (third commit).

I know that Espressif is phasing out nonos-sdk, but I prefer avoid arduino framework and still use these two ones until rtos3-sdk is available.

Support for the Espressif nonos-sdk (3.0.5) requires :
- a esp_init_data_default_v08.bin file which is different from original esp_init_data_default.bin
- information about flash size map
To achieve that, the platform builder : 
- create the correct file list and sets FLASH_EXTRA_IMAGES variable for the linker
- appends -DSPI_FLASH_SIZE_MAP=n to CCFLAGS for the compiler. main.c should handle this value accordingly to nonos-sdk notes.
A fork of latest Espressif nonos-sdk with the addition of package.json is available at https://github.com/freedib/framework-esp8266-nonos-sdk.

To support for legacy OTA, the platform must create binaries for user1 and user2 which can be stored on an http server. If direct upload is required, user1 binary must be uploaded.
A new "ota" target is created in main.py. If used, then OTA files be generated. If not, non OTA files will be generated.
A python tool (genbin.py) similar to Espressif's gen_appbin.py allow to extract elf sections and create flash.bin+irom0.text.bin (non OTA) or user1.bin+user2.bin (OTA).
To achieve that, the platform builder :
- sets BUILDERS/ElfToBin variable to call genbin.py with frequency, flash mode, memory parameters and name of output files.
- sets FLASH_EXTRA_IMAGES variable with final files list for the uploader
The same code is used for nonos-sdk and rtos-sdk.
genbin.py is already packaged for platformio and available at https://github.com/freedib/tool-genbin.
