### PR TITLE
Prefer latest toolchain-xtensa

### DIFF
--- a/platform.json
+++ b/platform.json
@@ -42,7 +42,7 @@
     "toolchain-xtensa": {
       "type": "toolchain",
       "owner": "platformio",
-      "version": "~2.100300.0",
+      "version": "~2.100300.220621",
       "optionalVersions": ["~1.40802.0"]
     },
     "framework-arduinoespressif8266": {


### PR DESCRIPTION
See https://github.com/esp8266/Arduino/pull/8393

Missed when updating to Core 3.1.x b/c semver still prefers old version installed.
Fix optimisation bug(s). Usually breaks on Windows, comes and goes at random so it is pretty annoying to debug

*May be* related to https://github.com/platformio/platform-espressif8266/issues/288, or any other 'this code sometimes works, but sometimes doesnt'