### PR TITLE
fix: Unable to upload to remote

### DIFF
--- a/builder/main.py
+++ b/builder/main.py
@@ -259,9 +259,6 @@ if env.get("PIOMAINPROG"):
         env.VerboseAction(
             lambda source, target, env: _update_max_upload_size(env),
             "Retrieving maximum program size $SOURCE"))
-# remove after PIO Core 3.6 release
-elif set(["checkprogsize", "upload"]) & set(COMMAND_LINE_TARGETS):
-    _update_max_upload_size(env)
 
 #
 # Target: Print binary size


### PR DESCRIPTION
When using `pio remote`, it appears this code remanent was preventing upload (to a `d1_mini` target), triggering an "Error: Could not find LD script" error to be shown.

It seems it should have been fixed in https://github.com/platformio/platform-espressif8266/commit/e69a2cb6d1f38f72ff7bff9d87707689b4fef739 but resurfaced at a later date. 

Fixes platformio/platformio-core#3580

