### PR TITLE
Add board esp8285_2m for generic 8285 with 2MiB flash

### DIFF
--- a/boards/esp8285_2m.json
+++ b/boards/esp8285_2m.json
@@ -1,0 +1,32 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "eagle.flash.2m256.ld"
+    },
+    "core": "esp8266",
+    "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DARDUINO_ESP8266_ESP01",
+    "f_cpu": "80000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "dout",
+    "mcu": "esp8266",
+    "variant": "esp8285"
+  },
+  "connectivity": [
+    "wifi"
+  ],
+  "frameworks": [
+    "arduino",
+    "esp8266-rtos-sdk",
+    "esp8266-nonos-sdk"
+  ],
+  "name": "Generic ESP8285 Module",
+  "upload": {
+    "maximum_ram_size": 81920,
+    "maximum_size": 2097152,
+    "require_upload_port": true,
+    "resetmethod": "ck",
+    "speed": 115200
+  },
+  "url": "http://www.esp8266.com/wiki/doku.php?id=esp8266-module-family",
+  "vendor": "Espressif"
+}


### PR DESCRIPTION
This file is identical to esp8285.json with two changes that bump the flash size from 1MiB to 2MiB:

The upload.maximum_size value of "2097152" is taken from modwifi.json which is another 2MiB flash board.

The build.arduino.ldscript value is modified from "eagle.flash.1m256.ld" to "eagle.flash.2m256.ld".  
---- Though modwifi.json (another 2MiB board) uses "eagle.flash.2m.ld" instead of "eagle.flash.2m256.ld", I have no insight which partition layout is preferable and am choosing to mimic the 1MiB esp8285.json board definition on the assumption that this is the proper choice for a generic board.