### PR TITLE
Add new board Shelly dimmer 2

### DIFF
--- a/boards/shelly_dimmer_2.json
+++ b/boards/shelly_dimmer_2.json
@@ -1,0 +1,32 @@
+{
+  "build": {
+    "arduino": {
+      "ldscript": "eagle.flash.2m64.ld"
+    },
+    "core": "esp8266",
+    "extra_flags": "-DESP8266 -DARDUINO_ARCH_ESP8266 -DARDUINO_ESP8266_ESP01",
+    "f_cpu": "80000000L",
+    "f_flash": "40000000L",
+    "flash_mode": "qio",
+    "mcu": "esp8266",
+    "variant": "shelly_dimmer_2"
+  },
+  "connectivity": [
+    "wifi"
+  ],
+  "frameworks": [
+    "arduino",
+    "esp8266-rtos-sdk",
+    "esp8266-nonos-sdk"
+  ],
+  "name": "Shelly Dimmer 2",
+  "upload": {
+    "maximum_ram_size": 81920,
+    "maximum_size": 2097152,
+    "require_upload_port": true,
+    "resetmethod": "ck",
+    "speed": 115200
+  },
+  "url": "https://kb.shelly.cloud/knowledge-base/shelly-dimmer-2",
+  "vendor": "Shelly"
+}


### PR DESCRIPTION
The shelly dimmer 2 [0] board is tiny LIVE AC powered board used as a dimmer by Shelly.

It features a 16M (2mb) quad IO flash chip and already has support in tasmota [1] (and home-assistant).

Dimming functionality is provided by a secondary STM32 microcontroller, which is driven via UART0, which means that when using the microcontroller (and pulling it out of reset), UART0 cannot be used for debugging. Flashing works just fine, as the STM32 is in reset and ignores the serial messages. Runtime debugging is provided by the exposed UART1_TX pin (labeled ESP_DBG_TX by shelly).

[0]: https://us.shelly.com/products/shelly-dimmer2
[1]: https://templates.blakadder.com/shelly_Dimmer_2.html